### PR TITLE
Add library vision doc and tone guidelines

### DIFF
--- a/.claude/commands/muse.md
+++ b/.claude/commands/muse.md
@@ -1,0 +1,47 @@
+You are a creative design partner for the Noisebridge Library project. Your role is to help brainstorm, provoke better ideas, and translate feelings and principles into concrete design decisions.
+
+## Context
+
+Noisebridge is a hackerspace in San Francisco. Its library contains 1,100+ books. This project builds tools and interfaces for book discovery, lending, and cataloging. But the deeper goal is to build something that embodies the *spirit* of what a hackerspace library should feel like — communal, curious, alive.
+
+The codebase lives at this repo. The data is in `data.csv`. The web app is in `web-app/`. Refer to the project's CLAUDE.md for technical details when needed.
+
+## Your Arc
+
+You have two modes, and you shift between them naturally based on the conversation:
+
+**Phase 1 — Riff Partner** (default starting mode)
+- Generate lots of ideas, examples, and analogies. Throw things at the wall.
+- Pull from other domains: indie bookstores, museum exhibits, community fridges, zine libraries, tool lending libraries, punk record shops, seed banks, little free libraries, coworking spaces.
+- Offer 3-5 variations when exploring a direction. Don't settle on the first idea.
+- Name feelings precisely. If the user says "I want it to feel welcoming," push further — welcoming like a coffee shop? Like a friend's living room? Like a stranger handing you a book on the bus?
+- Be bold. Suggest things that might be weird or unexpected. The user can filter.
+
+**Phase 2 — Reflective Mirror** (shift into this as patterns emerge)
+- When the user starts resonating with certain ideas, slow down.
+- Reflect back the throughline: "It sounds like what you keep coming back to is..."
+- Get precise about language. Help name the principle or feeling clearly.
+- Distill scattered ideas into a coherent direction.
+- Translate abstract feelings into concrete next steps: specific tools, UI patterns, interactions, or experiments to build.
+- Be quiet and intentional. Fewer ideas, more clarity.
+
+**How to shift**: Watch for signals — the user saying "yes, that," repeating a phrase, spending more time on one idea, or explicitly asking to focus. When you notice convergence, name it and shift.
+
+## Guidelines
+
+- Always start by asking what's on the user's mind — don't assume.
+- Feelings first, tools second. Understand the *why* before suggesting the *what*.
+- Ground suggestions in the Noisebridge context: communal ownership, open access, diverse skill levels, physical space constraints, unreliable internet, the hacker ethic.
+- When suggesting next steps, be specific enough to act on. Not "add social features" but "let people leave a one-sentence note inside a book's page, like a margin annotation from a stranger."
+- Reference what already exists in the project when relevant. Don't suggest rebuilding things that are already built.
+- **Watch your language.** This is a community project, not a product. Avoid corporate/PM jargon — words like "product," "feature," "stakeholder," "user engagement," "roadmap," "KPIs," "metrics." Use plain, human language instead. Say "what we're building" not "the product." Say "ideas" not "features." Say "what's next" not "roadmap." The doc should feel like it was written by someone who cares, not someone who manages.
+- It's fine to sketch rough UI ideas in words or ASCII when it helps.
+- Push back gently if ideas feel generic, safe, or like they could belong to any library app. The question is always: *what makes this feel like Noisebridge?*
+
+## Starting the Conversation
+
+When invoked, open with something like:
+
+"What's on your mind? Are you circling an idea, stuck on something, or just want to explore?"
+
+Keep it casual and inviting. Match the user's energy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,10 @@ Examples of experiments that might be built here:
 - **Analytics**: Reading patterns, popular genres, collection gaps
 - **Physical Interfaces**: Kiosk displays, label printing, location mapping
 
+### Tone and Language
+
+This is a community project, not a corporate product. Avoid PM jargon in docs, comments, and generated text — words like "product," "feature," "stakeholder," "user engagement," "roadmap," "KPIs," "metrics." Use plain, human language. Say "what we're building" not "the product." Say "ideas" not "features." Say "what's next" not "roadmap." Writing should feel like it comes from someone who cares, not someone who manages.
+
 ### Key Considerations for Noisebridge Context
 
 - **Shared Resource**: Books are communally owned and managed

--- a/vision/repo-vision.md
+++ b/vision/repo-vision.md
@@ -1,0 +1,136 @@
+# Noisebridge Library — Vision
+
+> This document was written collaboratively with Claude (Anthropic). All content has been reviewed and approved by Jordan.
+
+## What This Is
+
+The Noisebridge Library is more than a catalog of 1,100+ books. It's a cultural intervention — a set of tools, spaces, and invitations designed to shift the hackerspace from "come here to use tools" toward "come here to fill up." Reading is making. Browsing is making. Leaving a note for a stranger is making.
+
+## How We Want People to Feel
+
+- **Inspired to build.** Not just "that's interesting" but "I want to go make something right now."
+- **Refreshed from the capitalist/corporate slog.** For techies in the FAANG or startup world, the library as an antidote. A reminder of why you got into this stuff in the first place.
+- **A return to forgotten ideas.** There's treasure buried in these shelves — older tech manuals, strange references, out-of-print thinking — waiting to be cherished and revitalized.
+- **The feeling of completing your work, before you've started.** The library should make you feel capable. Like you're already the person who finishes projects. Being here gives you momentum.
+
+## Signs of Success
+
+These are cultural symptoms, not metrics. They tell us whether the library is actually working.
+
+1. **People come to Noisebridge just to read.** Dedicated reading spaces emerge. Cozy corners get used. The library has its own gravity — it creates a new kind of regular who comes to fill up, not just to build.
+
+2. **People leave annotations without being asked.** Sticky tabs, margin notes, messages for the next reader. The impulse to share what you found. This is the deepest signal — it reveals whether the community practices "everyone for themselves" or "we support each other."
+
+3. **People ask to borrow books.** The books stop being furniture and become tools people need. People trust the system enough to engage with it. They feel like part of the commons.
+
+## Design Principles
+
+### Feelings First, Tools Second
+
+Everything we build should trace back to one of the feelings above. If it doesn't make someone feel inspired, refreshed, connected to forgotten ideas, or capable — ask why we're building it.
+
+### The Tool Creates the Culture
+
+The catalog search serves people who already want to find a book. But the best interventions create *new behaviors* — turn non-readers into readers, turn solo users into contributors, turn a messy shelf into a communal project. Design for the behavior you want to see, not just the behavior that already exists.
+
+### Haunted in a Good Way
+
+The library should feel inhabited. Traces of everyone who came before — what they read, what inspired them, what they built because of it. Not sterile metadata, but evidence of life. Like Dark Souls messages: short, situated, anonymous but warm. Someone was here before you.
+
+### Physical and Digital as One System
+
+Inspired by Bret Victor's seeing spaces. The physical library wall and the app are the same wall — two surfaces of one system. A diagram scanned from a book appears in the app and gets printed for the physical wall. A QR code on the wall leads to the book's page, complete with community annotations. You don't have to think about which one you're using.
+
+### Emergence Over Design
+
+Start with randomness — the primordial soup. Let community contributions create structure over time. Themes, groupings, and curated highlights emerge bottom-up from use, not top-down from categories. Folksonomy, not taxonomy.
+
+## Aesthetic Direction
+
+The visual identity lives at the intersection of several tensions:
+
+| Precise | Chaotic |
+|---|---|
+| Blueprints, craftsmanship, technical diagrams | Collage, organic accumulation, many hands |
+
+| Past | Future |
+|---|---|
+| Retro, vintage tech manuals, book cover aesthetics | Solarpunk, tech revival, optimistic futures |
+
+These aren't contradictions. They describe the feeling of a **workshop wall** — blueprints pinned next to postcards next to circuit diagrams next to a photo of a geodesic dome. Curated *and* accumulated. Old references *and* future visions.
+
+**Reference points:**
+- The Whole Earth Catalog — a curated, opinionated, handmade guide to tools and ideas, explicitly anti-corporate, designed to make you feel like you could build anything
+- A well-used hackerspace workbench — stickers, burn marks, someone's half-finished project, a manual left open to the right page
+- Dark Souls message system — cryptic, helpful, left by strangers who walked the same path
+- Bret Victor's Dynamicland — digital and physical as one continuous environment
+
+## The Two Libraries
+
+The collection naturally splits into two modes with different spatial and digital needs:
+
+**The Reference Library** — tech manuals, programming books, electronics guides. Lives near workbenches. People pull a manual while building. Needs efficient search, QR access, proximity to work surfaces. The catalog search tool serves this well.
+
+**The Reading Library** — science fiction, philosophy, zines, ebooks (future). Needs a different kind of space: somewhere to sit, slow down, and absorb. This behavior is tough to find at Noisebridge because the physical space has other needs that conflict with it (desk space for computers, constantly rearranging, big machines). Creating this is as much a furniture problem as a software problem, and a successful version of this has to integrate with Noisebridge's other needs well.
+
+## Ideas We're Exploring
+
+### Community Annotations (Dark Souls Messages)
+
+Small messages left by readers on specific books. Not reviews — fragments. Maker annotations that point to moments of inspiration.
+
+- "Page 47 has the best circuit diagram I've ever seen"
+- "Read this after SICP, it clicks different"
+- "I built my first synth because of chapter 3"
+
+Short, situated, voteable. Good messages persist, others fade. The community speaks through the books.
+
+### The Collage Wall (`/collage` or `/wall`)
+
+A visual pinboard — masonry-style grid of images from the collection. Book covers, scanned diagrams, illustrations, code snippets photographed from pages. Not a search interface — a browsing-by-surprise interface.
+
+- Starts random (primordial soup)
+- Community members upload scans and photos from books they're reading
+- Bottom-up tags and themes emerge over time
+- Each tile links back to its source book in the catalog
+- Physical-digital loop: scans appear on the app and get printed for the physical wall at NB
+
+The inspiration engine. Unlikely combinations create new ideas.
+
+### Community Catalog Contributions
+
+Anyone can update the catalog — add new books, note when books change shelves, flag missing items. Organized chaos from community input. The catalog stays alive because the community maintains it.
+
+## What's Next
+
+### Right Now — Get the Basics Working
+- [x] Basic catalog search tool
+- [ ] Stabilize hosting
+- [ ] QR labels for catalog search
+- [ ] Shelf labels
+
+### Then — Listen
+- [ ] Talk to organizers: what do they notice people using books for?
+- [ ] Observe current behavior as a cultural probe
+- [ ] Identify existing informal practices worth amplifying
+
+### Then — Make the Space Inviting
+- [ ] Activate the downstairs shelf — curate it intentionally, stock it near the couches
+- [ ] Test whether proximity changes reading behavior
+- [ ] Explore reading station concepts (lamp, side table, invitation to linger)
+
+### Then — Build the Home
+- [ ] Community shelf-build project using the woodshop
+- [ ] Proper shelving system to replace cobbled-together units
+- [ ] The build itself is a community event — people who build the shelves invest in the library
+
+### Then — Add the Digital Layer
+- [ ] Community annotations on books
+- [ ] Collage wall / visual pinboard view
+- [ ] Community catalog contributions (add books, update locations)
+- [ ] Physical-digital loop (QR codes linking to annotated catalog pages)
+
+### Someday
+- [ ] Zines and ebooks as first-class citizens
+- [ ] Lending system that feels like trust, not paperwork
+- [ ] Themed collections emerging from community tags


### PR DESCRIPTION
## Summary

- Adds a **vision doc** (`vision/repo-vision.md`) capturing the spirit, principles, and direction for the Noisebridge library — what we want people to feel, signs of success, aesthetic direction, and what's next
- Adds **tone guidelines** to `CLAUDE.md` so generated text avoids corporate/PM jargon and sounds like a community project, not a product spec

## Context

This came out of a brainstorming session about what the library should *feel* like and what success looks like culturally (people reading, annotating, borrowing) rather than as metrics. The vision doc is meant to be approachable to community members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)